### PR TITLE
Updated dependencies and built using JDK 17.0.3 Zulu with JavaFX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,23 @@
 
     <properties>
         <main.class>us.hebi.histogram.visualizer.Visualizer</main.class>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
+	<dependency> <!-- API, java.xml.bind module -->
+	    <groupId>jakarta.xml.bind</groupId>
+	    <artifactId>jakarta.xml.bind-api</artifactId>
+	    <version>2.3.2</version>
+	</dependency>
+
+	<dependency> <!-- Runtime, com.sun.xml.bind module -->
+	    <groupId>org.glassfish.jaxb</groupId>
+	    <artifactId>jaxb-runtime</artifactId>
+	    <version>2.3.2</version>
+	</dependency>
 
         <dependency> <!-- JavaFX DI / CoC framework -->
             <groupId>com.airhacks</groupId>
@@ -56,7 +67,12 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+           <groupId>com.google.code.findbugs</groupId>
+           <artifactId>jsr305</artifactId>
+           <version>3.0.2</version>
+           <scope>compile</scope> <!-- Must have this where procesor runs -->
+        </dependency>
         <dependency> <!-- Useful JavaFX Controls -->
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
@@ -81,12 +97,44 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+        <dependency>
+           <groupId>javax.annotation</groupId>
+           <artifactId>javax.annotation-api</artifactId>
+           <version>1.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-
+	<plugin>
+	    <groupId>org.apache.maven.plugins</groupId>
+	    <artifactId>maven-compiler-plugin</artifactId>
+	    <version>3.8.1</version>
+	    <configuration>
+		<source>17</source>
+		<target>17</target>
+		<!-- <release>17</release>  -->
+		<fork>true</fork>
+		<compilerArgs>
+		    <arg>-Xlint:all</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+		    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED</arg>
+		</compilerArgs>
+		<!--for unmappable characters in classes-->
+		<encoding>UTF-8</encoding>
+		<showDeprecation>true</showDeprecation>
+		<showWarnings>true</showWarnings>
+	   </configuration>
+	</plugin>
             <plugin> <!-- Builds an assembly jar that includes dependencies -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
The build previously used and relied on JDK 8 and deprecated Java EE (JAXB) libraries. The shaded jar now works using the latest JDK 17.0.3 LTS release from Azul's Zulu builds including JavaFX modules.